### PR TITLE
Add multi-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
+FROM maven:3.6.3-jdk-8-slim as build
+
+COPY src /usr/src/app/src
+COPY pom.xml /usr/src/app
+RUN mvn -f /usr/src/app/pom.xml war:war
+
 FROM tomcat:8.5-alpine
 
-
-COPY ROOT.war /usr/local/tomcat/webapps/jalba.war
+COPY --from=build /usr/src/app/ROOT.war /usr/local/tomcat/webapps/jalba.war
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 
 ## Docker
 
-To run the application locally in a dockerized tomcat, run build.sh to get the war file built, then run 
+The provided Dockerfile will perform a self-contained multi-stage build, so just build the image and you are good to go:
 ```
 docker build -t jalba .
 ```
-to build the image and with
+
+Afterwards you can run a container based on the created image (internal port is `8080`)
 ``` 
 docker run -p 80:8080 jalba
 ```
-you can start the tomcat server with the deployed app available at [http://localhost/jalba/](http://localhost/jalba/)
+and the tomcat server will be started with the deployed app available at [http://localhost/jalba/](http://localhost/jalba/).


### PR DESCRIPTION
This will expand the Dockerfile to be a self-contained build of the whole image, meaning it is not necessary to have any Java or IDE locall installed and setup.

The first stage will build the war, the second stage (which is the resulting image) will just deploy the war file into Tomcat. 